### PR TITLE
Added swipebox-start and swipebox-destroy events.

### DIFF
--- a/source/jquery.swipebox.js
+++ b/source/jquery.swipebox.js
@@ -44,6 +44,7 @@
 				e.preventDefault();
 				e.stopPropagation();
 				index = $elem.index($(this));
+				ui.target = $(e.target);
 				ui.init(index);
 			});
 
@@ -52,6 +53,7 @@
 		var ui = {
 
 			init : function(index){
+				this.target.trigger('swipebox-start');
 				this.build();
 				this.openSlide(index);
 				this.openImg(index);
@@ -431,7 +433,8 @@
 				$('#swipebox-slider').unbind();
 				$('#swipebox-overlay').remove();
 				$elem.removeData('_swipebox');
-			}
+				this.target.trigger('swipebox-destroy');
+ 			}
 
 		}
 


### PR DESCRIPTION
Ive added two new events, swipebox-start and swipebox-destroy. To do this I
added a new member to the ui object, target. Target is the jquery selector that
initiated the swipebox with a onclick event. I needed this functionality to stop activity on the page that was interfering with the controls of Swipebox.
