### PR TITLE
Allow plugin's reinitialize

### DIFF
--- a/source/jquery.swipebox.js
+++ b/source/jquery.swipebox.js
@@ -49,6 +49,12 @@
 			});
 		}
 
+		plugin.refresh = function() {
+			ui.destroy();
+			$elem = $(selector);
+			ui.actions();
+		}
+
 		var ui = {
 
 			init : function(index){
@@ -432,7 +438,8 @@
 				$('#swipebox-slider').unbind();
 				$('#swipebox-overlay').remove();
 				$elem.removeData('_swipebox');
-				$this.target.trigger('swipebox-destroy');
+				if ( $this.target )
+					$this.target.trigger('swipebox-destroy');
  			}
 
 		}
@@ -446,6 +453,7 @@
 			var swipebox = new $.swipebox(this, options);
 			this.data('_swipebox', swipebox);
 		}
+		return this.data('_swipebox');
 	}
 
 }(window, document, jQuery));


### PR DESCRIPTION
Hello, this update creates a new "refresh" method to allow the refreshing of the plugin's instance.
This could be useful if for some reason the images which the plugin is instantiated on, are changing.
In my case I have a product's view page which contains the product's images separated by color.
If the user changes color the previous shown images become hidden and the new color's images become visible.

If for example the instance is this:
var swipeboxInstance = jQuery(".swipebox-image:visible").swipebox({
    useCSS: true,
    hideBarsDelay: 0
});

Using the next call the developer can refresh the plugin so the new color images are considered by the plugin:
    swipeboxInstance.refresh();

Bye
