### PR TITLE
Register SwipeBox as a Bower package...

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,5 @@
+{
+  "name": "swipebox",
+  "version": "1.2.1",
+  "main": "source/jquery.swipebox.js"
+}


### PR DESCRIPTION
I just started using Bower (http://bower.io) for front-end package management. I'd like to include SwipeBox in my project using Bower, but it first needs to be registered as a package in Bower.

I've never actually created or registered a Bower package before, but the process seemed pretty straightforward. The contents of this file were generated by running "bower init" as specified at http://bower.io under the heading "Defining a Package".

After adding this file, the next step would be to register the package with Bower, using this command:

> bower register swipebox git://github.com/brutaldesign/swipebox.git
