### PR TITLE
Only bind next/prev/close to click, not click and touchend

### DIFF
--- a/source/jquery.swipebox.js
+++ b/source/jquery.swipebox.js
@@ -379,14 +379,14 @@
 				if( elements.length < 2 ){
 					$('#swipebox-prev, #swipebox-next').hide();
 				}else{
-					$('#swipebox-prev').bind('click touchend', function(e){
+					$('#swipebox-prev').bind('click', function(e){
 						e.preventDefault();
 						e.stopPropagation();
 						$this.getPrev();
 						$this.setTimeout();
 					});
 					
-					$('#swipebox-next').bind('click touchend', function(e){
+					$('#swipebox-next').bind('click', function(e){
 						e.preventDefault();
 						e.stopPropagation();
 						$this.getNext();
@@ -394,7 +394,7 @@
 					});
 				}
 
-				$('#swipebox-close').bind('click touchend', function(e){
+				$('#swipebox-close').bind('click', function(e){
 					$this.closeSlide();
 				});
 			},


### PR DESCRIPTION
This fixes an issue in Android 4.2 browser where the handler fires twice (e.g. skipping an image when clicking prev/next).
