### PR TITLE
Allow custom attribute names for 'href' and 'title'

### DIFF
--- a/source/jquery.swipebox.js
+++ b/source/jquery.swipebox.js
@@ -19,7 +19,9 @@
 			videoMaxWidth : 1140,
 			vimeoColor : 'CCCCCC',
 			beforeOpen: null,
-		      	afterClose: null
+			afterClose: null,
+			titleAttribute: 'title',
+			hrefAttribute: 'href'
 		},
 		
 		plugin = this,
@@ -74,11 +76,11 @@
 
 						var title = null, href = null;
 						
-						if( $(this).attr('title') )
-							title = $(this).attr('title');
+						if( $(this).attr(plugin.settings.titleAttribute) )
+							title = $(this).attr(plugin.settings.titleAttribute);
 
-						if( $(this).attr('href') )
-							href = $(this).attr('href');
+						if( $(this).attr(plugin.settings.hrefAttribute) )
+							href = $(this).attr(plugin.settings.hrefAttribute);
 
 						elements.push({
 							href: href,


### PR DESCRIPTION
I wanted to conform to the Bootstrap-style data-attr-name format for passing attributes to plugins, creating options for 'titleAttribute' and 'hrefAttribute' allow users to pass a custom attribute name on to the plugin, or just use 'href' and 'title'
