### PR TITLE
Update jquery.swipebox.js

### DIFF
--- a/source/jquery.swipebox.js
+++ b/source/jquery.swipebox.js
@@ -174,17 +174,33 @@
 				
 				if( "onorientationchange" in window ){
 
-					window.addEventListener("orientationchange", function() {
-						if( window.orientation == 0 ){
-							width = winWidth;
-							height = winHeight;
-						}else if( window.orientation == 90 || window.orientation == -90 ){
-							width = winHeight;
-							height = winWidth;
-						}
-					}, false);
-					
-				
+					if (!window.addEventListener) {
+	                                
+						window.attachEvent("orientationchange", function() {
+	                                            if( window.orientation == 0 ){
+	                                                    width = winWidth;
+	                                                    height = winHeight;
+	                                            }else if( window.orientation == 90 || window.orientation == -90 ){
+	                                                    width = winHeight;
+	                                                    height = winWidth;
+	                                            }
+	                                        });
+									    
+					} else {
+									
+						window.addEventListener("orientationchange", function() {
+	                                            if( window.orientation == 0 ){
+	                                                    width = winWidth;
+	                                                    height = winHeight;
+	                                            }else if( window.orientation == 90 || window.orientation == -90 ){
+	                                                    width = winHeight;
+	                                                    height = winWidth;
+	                                            }
+	                                        }, false);
+									    
+					}
+
+
 				}else{
 
 					width = window.innerWidth ? window.innerWidth : $(window).width();


### PR DESCRIPTION
Starting on line 177, addEventListener is invoked. addEventListener is not supported in IE8 and earlier, so I've added support for attachEvent. The code now works on IE8 and earlier versions of IE.
