### PR TITLE
download button added

### DIFF
--- a/source/jquery.swipebox.js
+++ b/source/jquery.swipebox.js
@@ -19,7 +19,8 @@
 			videoMaxWidth : 1140,
 			vimeoColor : 'CCCCCC',
 			beforeOpen: null,
-		      	afterClose: null
+		    afterClose: null,
+            downloadIndicator: 'href'
 		},
 		
 		plugin = this,
@@ -36,6 +37,7 @@
 				<div id="swipebox-caption"></div>\
 				<div id="swipebox-action">\
 					<a id="swipebox-close"></a>\
+                    <a id="swipebox-download"></a>\
 					<a id="swipebox-prev"></a>\
 					<a id="swipebox-next"></a>\
 				</div>\
@@ -80,9 +82,13 @@
 						if( $(this).attr('href') )
 							href = $(this).attr('href');
 
+						if( $(this).attr(options.downloadIndicator) )
+							download = $(this).attr(options.downloadIndicator);
+                        
 						elements.push({
 							href: href,
-							title: title
+							title: title,
+                            download: download
 						});
 					});
 					
@@ -413,6 +419,7 @@
 				$('#swipebox-slider .slide').removeClass('current');
 				$('#swipebox-slider .slide').eq(index).addClass('current');
 				this.setTitle(index);
+                this.setDownload(index);
 
 				if( isFirst ){
 					slider.fadeIn();
@@ -479,6 +486,21 @@
 					$('#swipebox-caption').append(title);
 				}
 			},
+
+            setDownload : function (index, isFirst){
+                var download = null;
+
+                $('#swipebox-download').empty();
+
+				if( elements[index] !== undefined )
+					orig = elements[index].download;
+				
+				if(orig){
+					$('#swipebox-download').attr('href', orig);
+                    $('#swipebox-download').attr('title', 'Download');
+				}
+            },
+
 
 			isVideo : function (src){
 

--- a/source/swipebox.css
+++ b/source/swipebox.css
@@ -117,7 +117,7 @@ html.swipebox {
 }
 
 #swipebox-action #swipebox-prev, #swipebox-action #swipebox-next,
-#swipebox-action #swipebox-close {
+#swipebox-action #swipebox-close, #swipebox-download{
   background-image: url("img/icons.png");
   background-repeat: no-repeat;
   border: none!important;
@@ -132,6 +132,14 @@ html.swipebox {
 #swipebox-action #swipebox-close {
   background-position: 15px 12px;
   left: 40px;
+}
+
+#swipebox-action #swipebox-download {
+  background-position: -78px 13px;
+  transform: rotate(90deg);
+  -ms-transform: rotate(90deg); /* IE 9 */
+  -webkit-transform: rotate(90deg);
+  left: 80px;
 }
 
 #swipebox-action #swipebox-prev {


### PR DESCRIPTION
Add a small downloadbutton next to the close button

new option:

```
downloadIndicator: 'href'
```

downloadIndicator allows to use a orig File as download

example:

```
<a rel="gallery-1" href="big/image2.jpg" class="swipebox" orig="original/image2.jpg">
    <img src="small/image2.jpg" alt="image">
</a>

<script type="text/javascript">
        jQuery(function($) {
            $(".swipebox").swipebox({
                downloadIndicator : 'orig'
            });
        });
</script>
```
