### PR TITLE
fixed issue with immediate swipebox reopen in native android browser

### DIFF
--- a/src/js/jquery.swipebox.js
+++ b/src/js/jquery.swipebox.js
@@ -125,6 +125,9 @@
 			 * Initiate Swipebox
 			 */
 			init : function( index ) {
+				if ($.swipebox.preventReopenFlag) {
+					return;
+				}
 				if ( plugin.settings.beforeOpen ) 
 					plugin.settings.beforeOpen();
 				this.target.trigger( 'swipebox-start' );
@@ -677,6 +680,12 @@
 				$( 'html' ).removeClass( 'swipebox-touch' );
 				$( window ).trigger( 'resize' );
 				this.destroy();
+
+				//prevent immediate reopen in native android browser
+				$.swipebox.preventReopenFlag = true;
+				window.setTimeout(function () {
+					$.swipebox.preventReopenFlag = false;
+				}, 500);
 			},
 
 			/**


### PR DESCRIPTION
try to click on "x" in android native browser. It will close swipebox and at the same time this click will go "behind" swipebox. Usually "behind" are images and clicking there we immediately reopen it. 
Fixed using protected interval - kinda dirty hack but truly working.
Reproducible on android 2.x - 4.x devices in native browser.
