### PR TITLE
declare $elem as local var

### DIFF
--- a/src/js/jquery.swipebox.js
+++ b/src/js/jquery.swipebox.js
@@ -33,7 +33,8 @@
 					<a id="swipebox-prev"></a>\
 					<a id="swipebox-next"></a>\
 				</div>\
-		</div>';
+		</div>',
+		$elem;
 
 		plugin.settings = {};
 


### PR DESCRIPTION
The variable $elem isn't declared in plugin scope so it gets global. This can lead to problems if the plugin gets used in a strict environment.
