### PR TITLE
Add option to use 'data-title' instead of 'title' attribute

### DIFF
--- a/src/js/jquery.swipebox.js
+++ b/src/js/jquery.swipebox.js
@@ -108,14 +108,10 @@
 
 					$elem.each( function() {
 
-						var title = null,
-							href = null;
+						var titleAttr = $( this ).attr( 'title' );
+						var title = titleAttr ? titleAttr : $( this ).data( 'title' );
 
-						if ( $( this ).attr( 'title' ) ) {
-							title = $( this ).attr( 'title' );
-						}
-
-
+						var href = null;
 						if ( $( this ).attr( 'href' ) ) {
 							href = $( this ).attr( 'href' );
 						}


### PR DESCRIPTION
For my use case I don't want the link (that launches swipebox) to pop up a tooltip when hovering over it (I'm using swipebox along with [Justfied-Gallery](http://miromannino.github.io/Justified-Gallery/)). Giving the option to use `data-title` instead of the `title` attribute solves it. The `title` attribute remains the main means to specify your title.

P.S. Thanks for the great library!