### PR TITLE
Handle case when no query parameters are present

### DIFF
--- a/src/js/jquery.swipebox.js
+++ b/src/js/jquery.swipebox.js
@@ -743,8 +743,10 @@
 				a.href = decodeURIComponent( uri );
 
 				// QueryString to Object
-				qs = JSON.parse( '{"' + a.search.toLowerCase().replace('?','').replace(/&/g,'","').replace(/=/g,'":"') + '"}' );
-
+				if ( a.search ) {
+					qs = JSON.parse( '{"' + a.search.toLowerCase().replace('?','').replace(/&/g,'","').replace(/=/g,'":"') + '"}' );
+				}
+				
 				// Extend with custom data
 				if ( $.isPlainObject( customData ) ) {
 					qs = $.extend( qs, customData, plugin.settings.queryStringData ); // The dev has always the final word


### PR DESCRIPTION
Without this conditional, JSON.parse will throw an error as we return {""}, which is invalid. This fixes #224