### PR TITLE
fix a problem with jshint

### DIFF
--- a/grunt/gruntfile.js
+++ b/grunt/gruntfile.js
@@ -84,7 +84,8 @@ module.exports = function(grunt) {
 		// chech our JS
 		jshint: {
 			options : {
-				jshintrc : '.jshintrc'
+				jshintrc : '.jshintrc',
+				reporterOutput : ''
 			},
 			all: [ '../src/js/jquery.swipebox.js' ]
 		},


### PR DESCRIPTION
I had problems running grunt because of this issue:
https://github.com/jshint/jshint/issues/2922

I used one of the recommended fixes from there. I'm not exactly sure
what it does, but it helped me to get grunt run through again.