### PR TITLE
Add event.preventDefault and event.stopPropagation to #swipebox-close

### DIFF
--- a/src/js/jquery.swipebox.js
+++ b/src/js/jquery.swipebox.js
@@ -584,7 +584,9 @@
 					} );
 				}
 
-				$( '#swipebox-close' ).bind( action, function() {
+				$( '#swipebox-close' ).bind( action, function( event ) {
+					event.preventDefault();
+					event.stopPropagation();
 					$this.closeSlide();
 				} );
 			},


### PR DESCRIPTION
I found that when using Swipebox with a fixed header. The click event passed through the close button to the elements behind. Specifically, this happens for Chrome on Android but does not seem to happen on iOS. The changes in this pull request should not interfere with expected functionality.

This pull request does not modify the minified version of this script, so that step would need to be done to consider this issue finalized.

Great work, thanks.