### PR TITLE
docs: Fix simple typo, rught -> right

### DIFF
--- a/src/js/jquery.swipebox.js
+++ b/src/js/jquery.swipebox.js
@@ -357,7 +357,7 @@
 									} );
 								}
 
-							// swipe rught
+							// swipe right
 							} else if ( 0 > hDistance ) {
 
 								// last Slide


### PR DESCRIPTION
There is a small typo in src/js/jquery.swipebox.js.

Should read `right` rather than `rught`.

